### PR TITLE
先用django-markup-deprecated臨時修復restructuredtext渲染的問題

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ wsgiref==0.1.2
 pytest-django==2.6.2
 django-sendmail-backend==0.1.2
 pytest-random==0.02
+django-markup-deprecated==0.0.3

--- a/settings.py
+++ b/settings.py
@@ -130,6 +130,7 @@ INSTALLED_APPS = (
     #TODO: take the unittest framework back
     'south',
     'django_xmlrpc',
+    'markup_deprecated',
     'apps.core',
     'apps.member',
     'apps.twitter',

--- a/templates/core/topic.html
+++ b/templates/core/topic.html
@@ -1,6 +1,7 @@
 {% extends "core/base_core.html" %}
 {% block title %} - {{this_topic.name}}{% endblock %}
 {% block content %}
+    {% load markup %}
     <div id="content" class="content topic row">
       <div class="span12">
         <p class="bread-crumb"><a href="/topic">返回话题列表</a></p>
@@ -40,7 +41,11 @@
         {% include 'core/_share_link.html' %}
 
         <div class="typo">
+          {% if this_topic.content_type == 'restructuredtext' %}
+          {{ this_topic.content|restructuredtext }}
+          {% else %}
           {{ this_topic.rendered_content|safe }}
+          {% endif %}
         </div>
 
         {% if modified %}


### PR DESCRIPTION
cc @Tin @CNBorn @loddit

先解決現在渲染不正確的問題 #61 ，可以把markdown的轉換放到workshop做

pls, review :beer: 
